### PR TITLE
Backtrace: Add support for unwinding across exception returns

### DIFF
--- a/backtrace/backtrace.c
+++ b/backtrace/backtrace.c
@@ -226,17 +226,17 @@ static int unwind_execute_instruction(unwind_control_block_t *ucb)
 	return instruction != -1;
 }
 
-static inline __attribute__((always_inline)) unsigned int *readPSP(void)
+static inline __attribute__((always_inline)) uint32_t *read_psp(void)
 {
 	/* Read the current PSP and return its value as a pointer */
-	unsigned int psp;
+	uint32_t psp;
 
 	__asm volatile (
 		"   mrs %0, psp \n"
 		: "=r" (psp) : :
 	);
 
-	return (unsigned int*)psp;
+	return (uint32_t*)psp;
 }
 
 /* TODO How do I range check the stack pointer */
@@ -309,7 +309,7 @@ static int unwind_frame(backtrace_frame_t *frame)
 		}
 		else {
 			/* Return to Thread Mode: PSP (0xffffff-d) */
-			stack = readPSP();
+			stack = read_psp();
 
 			/* The PC is always 6 words up from the PSP */
 			stack += 6;

--- a/backtrace/backtrace.c
+++ b/backtrace/backtrace.c
@@ -338,7 +338,6 @@ static int unwind_frame(backtrace_frame_t *frame)
 
 int _backtrace_unwind(backtrace_t *buffer, int size, backtrace_frame_t *frame)
 {
-	const unwind_index_t *index;
 	int count = 0;
 
 	/* Initialize the backtrace frame buffer */
@@ -356,6 +355,13 @@ int _backtrace_unwind(backtrace_t *buffer, int size, backtrace_frame_t *frame)
 			/* Reached .cantunwind instruction. */
 			buffer[count++].name = "<reached .cantunwind>";
 			break;
+		}
+
+		/* Find the unwind index of the current frame pc */
+		const unwind_index_t *index = unwind_search_index(__exidx_start, __exidx_end, frame->pc);
+
+		/* Clear last bit (Thumb indicator) */
+		frame->pc &= 0xfffffffeU;
 
 		/* Generate the backtrace information */
 		buffer[count].address = (void *)frame->pc;

--- a/backtrace/backtrace.c
+++ b/backtrace/backtrace.c
@@ -275,6 +275,53 @@ static int unwind_frame(backtrace_frame_t *frame)
 	if (ucb.vrs[15] == 0)
 		ucb.vrs[15] = ucb.vrs[14];
 
+	/* Check for exception return */
+	/* TODO Test with other ARM processors to verify this method. */
+	if ((ucb.vrs[15] & 0xf0000000) == 0xf0000000) {
+		/* According to the Cortex Programming Manual (p.44), the stack address is always 8-byte aligned (Cortex-M7).
+		   Depending on where the exception came from (MSP or PSP), we need the right SP value to work with.
+
+		   ucb.vrs[7] contains the right value, so take it and align it by 8 bytes, store it as the current
+		   SP to work with (ucb.vrs[13]) which is then saved as the current (virtual) frame's SP.
+		*/
+		uint32_t *stack;
+		ucb.vrs[13] = (ucb.vrs[7] & ~7);
+
+		/* If we need to start from the MSP, we need to go down X words to find the PC, where:
+				X=2  if it was a non-floating-point exception
+				X=20 if it was a floating-point (VFP) exception
+
+		   If we need to start from the PSP, we need to go up exactly 6 words to find the PC.
+		   See the ARMv7-M Architecture Reference Manual p.594 and Cortex-M7 Processor Programming Manual p.44/p.45 for details.
+		*/
+		if ((ucb.vrs[15] & 0xc) == 0) {
+			/* Return to Handler Mode: MSP (0xffffff-1) */
+			stack = (uint32_t*)(ucb.vrs[13]);
+
+			/* The PC is always 2 words down from the MSP, if it was a non-floating-point exception */
+			stack -= 2;
+
+			/* If there was a VFP exception (0xffffffe1), the PC is located another 18 words down */
+			if ((ucb.vrs[15] & 0xf0) == 0xe0)
+			{
+				stack -= 18;
+			}
+		}
+		else {
+			/* Return to Thread Mode: PSP (0xffffff-d) */
+			stack = readPSP();
+
+			/* The PC is always 6 words up from the PSP */
+			stack += 6;
+		}
+
+		/* Store the PC */
+		ucb.vrs[15] = *stack--;
+
+		/* Store the LR */
+		ucb.vrs[14] = *stack--;
+	}
+
 	/* We are done if current frame pc is equal to the virtual pc, prevent infinite loop */
 	if (frame->pc == ucb.vrs[15])
 		return 0;

--- a/backtrace/backtrace.c
+++ b/backtrace/backtrace.c
@@ -226,6 +226,19 @@ static int unwind_execute_instruction(unwind_control_block_t *ucb)
 	return instruction != -1;
 }
 
+static inline __attribute__((always_inline)) unsigned int *readPSP(void)
+{
+	/* Read the current PSP and return its value as a pointer */
+	unsigned int psp;
+
+	__asm volatile (
+		"   mrs %0, psp \n"
+		: "=r" (psp) : :
+	);
+
+	return (unsigned int*)psp;
+}
+
 /* TODO How do I range check the stack pointer */
 static int unwind_frame(backtrace_frame_t *frame)
 {


### PR DESCRIPTION
- Add VFP support
- Use the right SP (MSP or PSP) depending on what the unwinding instruction / exception return indicates

This has been successfully tested with the Cortex-M7 CPU. Feel free to pull and test with other ARM CPUs aswell.