### PR TITLE
fix SP not being updated after instruction 0x80

### DIFF
--- a/backtrace/backtrace.c
+++ b/backtrace/backtrace.c
@@ -138,11 +138,6 @@ static int unwind_execute_instruction(unwind_control_block_t *ucb)
 			vsp = (uint32_t *)ucb->vrs[13];
 			mask = instruction & 0xfff;
 
-			/* Update the vrs sp as usual if r13 (sp) was not in the mask,
-			 * otherwise leave the popped r13 as is. */
-			if ((mask & (1 << (13 - 4))) == 0)
-				ucb->vrs[13] = (uint32_t)vsp;
-
 			/* Loop through the mask */
 			reg = 4;
 			while (mask != 0) {
@@ -152,6 +147,10 @@ static int unwind_execute_instruction(unwind_control_block_t *ucb)
 				++reg;
 			}
 
+			/* Update the vrs sp as usual if r13 (sp) was not in the mask,
+			 * otherwise leave the popped r13 as is. */
+			if ((mask & (1 << (13 - 4))) == 0)
+				ucb->vrs[13] = (uint32_t)vsp;
 
 		} else if ((instruction & 0xf0) == 0x90 && instruction != 0x9d && instruction != 0x9f) {
 			/* vsp = r[nnnn] */


### PR DESCRIPTION
Currently the SP is not updated after all registers are loaded from the stack. The code in line [143](https://github.com/red-rocket-computing/backtrace/blob/master/backtrace/backtrace.c#L143) does nothing when R13 is not explicitly loaded.

My proposition is that it should be moved below.

I figured it out myself after a couple hours of debugging the stack but in the android kernel it is also done this way. Please check [here](https://android.googlesource.com/kernel/msm/+/android-msm-flo-3.4-kitkat-mr0/arch/arm/kernel/unwind.c#272)

Cheers,
M